### PR TITLE
Fix iOS SDK 18.5 compatibility

### DIFF
--- a/flutter_lyra/README.md
+++ b/flutter_lyra/README.md
@@ -77,7 +77,7 @@ Prerequisites:
 - In your `ios/Podfile`, update your ios sdk version :
 
 ```rb
-platform :ios, '11.0'
+platform :ios, '15.1'
 ```
 
 ## About Lyra

--- a/flutter_lyra/pubspec.yaml
+++ b/flutter_lyra/pubspec.yaml
@@ -22,9 +22,9 @@ dependencies:
   equatable: ^2.0.5
   flutter:
     sdk: flutter
-  flutter_lyra_android: ^0.4.0
+  flutter_lyra_android: ^0.5.0
   flutter_lyra_ios: ^0.5.0
-  flutter_lyra_platform_interface: ^0.4.0
+  flutter_lyra_platform_interface: ^0.5.0
 dev_dependencies:
   analyzer: ^4.7.0
   flutter_test:

--- a/flutter_lyra_android/CHANGELOG.md
+++ b/flutter_lyra_android/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.5.0
+
+- **BREAKING CHANGE**: [iOS] Minimum iOS deployment target increased from 11.0 to 15.1
+- **FIX**: [iOS] Update LyraPaymentSDK from ~2.7.7 to ~2.8.0 to fix iOS SDK 18.5 compatibility issues
+- **FIX**: [iOS] Resolve C++ static assertion failures with Sentry dependency by using LyraPaymentSDK 2.8.0+ which removes Sentry dependency
+
 # 0.4.0
 
 - [Android] Upgrade kotlin version

--- a/flutter_lyra_android/pubspec.yaml
+++ b/flutter_lyra_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_lyra_android
 description: Android implementation of the flutter_lyra plugin
 
-version: 0.4.0
+version: 0.5.0
 
 homepage: https://github.com/bamlab/Flutter-Lyra
 repository: https://github.com/bamlab/Flutter-Lyra
@@ -22,7 +22,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_lyra_platform_interface: ^0.4.0
+  flutter_lyra_platform_interface: ^0.5.0
 dev_dependencies:
   analyzer: ^5.13.0
   flutter_test:

--- a/flutter_lyra_ios/pubspec.yaml
+++ b/flutter_lyra_ios/pubspec.yaml
@@ -19,7 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_lyra_platform_interface: ^0.4.0
+  flutter_lyra_platform_interface: ^0.5.0
 dev_dependencies:
   analyzer: ^4.7.0
   flutter_test:

--- a/flutter_lyra_platform_interface/CHANGELOG.md
+++ b/flutter_lyra_platform_interface/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.5.0
+
+- **BREAKING CHANGE**: [iOS] Minimum iOS deployment target increased from 11.0 to 15.1
+- **FIX**: [iOS] Update LyraPaymentSDK from ~2.7.7 to ~2.8.0 to fix iOS SDK 18.5 compatibility issues
+- **FIX**: [iOS] Resolve C++ static assertion failures with Sentry dependency by using LyraPaymentSDK 2.8.0+ which removes Sentry dependency
+
 # 0.4.0
 
 - [Android] Upgrade kotlin version

--- a/flutter_lyra_platform_interface/pubspec.yaml
+++ b/flutter_lyra_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_lyra_platform_interface
 description: A common platform interface for the flutter_lyra plugin.
-version: 0.4.0
+version: 0.5.0
 homepage: https://github.com/bamlab/Flutter-Lyra
 repository: https://github.com/bamlab/Flutter-Lyra
 


### PR DESCRIPTION
## Summary
- align android and platform interface package versions with 0.5.0
- update dependencies to use `^0.5.0`
- note new 0.5.0 entries in changelogs
- document iOS deployment target 15.1 in README
- expand 0.5.0 changelogs with details about iOS changes

## Testing
- `melos run test` *(fails: command not found)*
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68578cbd1d24832a9de2eea589c7ff70